### PR TITLE
Partial path finding

### DIFF
--- a/Benchmark/Program.cs
+++ b/Benchmark/Program.cs
@@ -26,33 +26,37 @@ namespace Benchmark
                     cost += 0.5f;
                 }
             }
-        }        
+        }
 
         [Benchmark]
         public void Gradient100X100()
         {
-            this.GridWithSlope.GetPath(
+            this.GridWithSlope.TryGetPath(
                 new Position(0, 0),
                 new Position(this.GridWithSlope.DimX - 1, this.GridWithSlope.DimY - 1),
-                MovementPatterns.Full);
+                MovementPatterns.Full,
+                AgentShapes.Dot,
+                out _);
         }
 
         [Benchmark]
         public void Gradient100X100Limited()
         {
-            this.GridWithSlope.GetPath(
+            this.GridWithSlope.TryGetPath(
                 new Position(0, 0),
                 new Position(this.GridWithSlope.DimX - 1, this.GridWithSlope.DimY - 1),
                 MovementPatterns.Full,
-                int.MaxValue);
+                AgentShapes.Dot,
+                int.MaxValue,
+                out _);
         }
     }
 
     public class Program
     {
         public static void Main(string[] args)
-        {           
-            BenchmarkRunner.Run<AStarBenchmark>();            
+        {
+            BenchmarkRunner.Run<AStarBenchmark>();
             Console.ReadLine();
         }
     }

--- a/Roy-T.AStar/Boundary.cs
+++ b/Roy-T.AStar/Boundary.cs
@@ -15,6 +15,67 @@ namespace RoyT.AStar
         public int Y2 { get; set; }
 
         /// <summary>
+        /// Consructor
+        /// </summary>
+        /// <param name="x1">Top left X coordinate</param>
+        /// <param name="y1">Top left Y coordinate</param>
+        /// <param name="x2">Bottom right X coordinate</param>
+        /// <param name="y2">Bottom right Y coordinate</param>
+        public Boundary(int x1, int y1, int x2, int y2)
+        {
+            X1 = x1;
+            Y1 = y1;
+            X2 = x2;
+            Y2 = y2;
+        }
+
+        /// <summary>
+        /// Boundary from rectangle
+        /// </summary>
+        /// <param name="x">Top left X coordinate</param>
+        /// <param name="y">Top left Y coordinate</param>
+        /// <param name="width">Rectangle width</param>
+        /// <param name="height">Rectangle heigth</param>
+        /// <returns>Boundary made from rectangle</returns>
+        public static Boundary FromRectangle(int x, int y, int width, int height)
+        {
+            if (width < 1)
+            {
+                throw new ArgumentOutOfRangeException("Width can't be less than 1");
+            }
+
+            if (height < 1)
+            {
+                throw new ArgumentOutOfRangeException("Height can't be less than 1");
+            }
+
+            return new Boundary(x, y, x + width - 1, y + height - 1);
+        }
+
+        /// <summary>
+        /// Boundary from grid size and agent shape
+        /// </summary>
+        /// <param name="width">Grid width</param>
+        /// <param name="height">Grid height</param>
+        /// <returns>Boundary which ensured any part of agent can't get outside of grid</returns>
+        public static Boundary FromSizeAndShape(int width, int height, AgentShape shape)
+        {
+            if (width < 1)
+            {
+                throw new ArgumentOutOfRangeException("Width can't be less than 1");
+            }
+
+            if (height < 1)
+            {
+                throw new ArgumentOutOfRangeException("Height can't be less than 1");
+            }
+
+            return new Boundary(
+                -shape.TopLeft.X, -shape.TopLeft.Y,
+                width - shape.BottomRight.X - 1, height - shape.BottomRight.Y - 1);
+        }
+
+        /// <summary>
         /// Is position inside boundary ?
         /// </summary>
         /// <param name="p">Position</param>

--- a/Roy-T.AStar/Grid.cs
+++ b/Roy-T.AStar/Grid.cs
@@ -105,7 +105,7 @@ namespace RoyT.AStar
         /// </summary>
         /// <param name="position">A position inside the grid</param>
         /// <returns>The cost</returns>
-        internal float GetCellCostUnchecked(Position position)
+        public float GetCellCostUnchecked(Position position)
         {
             return this.Weights[GetIndexUnchecked(position)];
         }
@@ -117,7 +117,7 @@ namespace RoyT.AStar
         /// <param name="position">A position inside the grid</param>
         /// <param name="shape">Shape of the agent</param>
         /// <returns>The cost</returns>
-        internal float GetCellCostUnchecked(Position position, AgentShape shape)
+        public float GetCellCostUnchecked(Position position, AgentShape shape)
         {
             return shape.Cells.Max(d => Weights[GetIndexUnchecked(position + d)]);
         }

--- a/Roy-T.AStar/Grid.cs
+++ b/Roy-T.AStar/Grid.cs
@@ -51,6 +51,16 @@ namespace RoyT.AStar
         public int DimY { get; }
 
         /// <summary>
+        /// Is position inside grid ?
+        /// </summary>
+        /// <param name="p">Position</param>
+        /// <returns>true if position is inside grid</returns>
+        public bool IsInside(Position p)
+        {
+            return (p.X >= 0) && (p.X < DimX) && (p.Y >= 0) && (p.Y < DimY);
+        }
+
+        /// <summary>
         /// Sets the cost for traversing a cell
         /// </summary>
         /// <param name="position">A position inside the grid</param>

--- a/Roy-T.AStar/Grid.cs
+++ b/Roy-T.AStar/Grid.cs
@@ -118,9 +118,10 @@ namespace RoyT.AStar
         /// </summary>
         /// <param name="start">The start position</param>
         /// <param name="end">The end position</param>
-        /// <returns>Positions along the shortest path from start to end, or an empty array if no path could be found</returns>
-        public Position[] GetPath(Position start, Position end)
-            => GetPath(start, end, MovementPatterns.Full, AgentShapes.Dot);
+        /// <param name="path">Returns shortest path from start to the end if found. Can also return partial path if end is not reachable. In case of error returns empty array.</param>
+        /// <returns>Result of the path finding.</returns>
+        public PathFindResult TryGetPath(Position start, Position end, out Position[] path)
+            => TryGetPath(start, end, MovementPatterns.Full, AgentShapes.Dot, out path);
 
         /// <summary>
         /// Computes the lowest-cost path from start to end inside the grid for an agent with a custom
@@ -130,26 +131,17 @@ namespace RoyT.AStar
         /// <param name="end">The end position</param>
         /// <param name="movementPattern">The movement pattern of the agent, <see cref="MovementPatterns"/> for several built-in options</param>
         /// <param name="shape">Shape of the agent</param>
-        /// <returns>Positions along the shortest path from start to end, or an empty array if no path could be found</returns>
-        public Position[] GetPath(Position start, Position end, Offset[] movementPattern, AgentShape shape)
+        /// <param name="path">Returns shortest path from start to the end if found. Can also return partial path if end is not reachable. In case of error returns empty array.</param>
+        /// <returns>Result of the path finding.</returns>
+        public PathFindResult TryGetPath(Position start, Position end, Offset[] movementPattern, AgentShape shape, out Position[] path)
         {
-            var current = PathFinder.FindPath(this, start, end, movementPattern, shape);
-
-            if (current == null)
-            {
-                return new Position[0];
-            }
+            var result = PathFinder.TryFindPath(this, start, end, movementPattern, shape, out List<Position> positionList);
 
             // The Pathfinder returns the positions that found the end. If we want
             // to list positions from start to end we need reverse the traversal.
-            var steps = new Stack<Position>();
-            
-            foreach (var step in current)
-            {
-                steps.Push(step);
-            }
+            path = Enumerable.Reverse(positionList).ToArray();
 
-            return steps.ToArray();
+            return result;
         }
 
         /// <summary>
@@ -161,26 +153,17 @@ namespace RoyT.AStar
         /// <param name="movementPattern">The movement pattern of the agent, <see cref="MovementPatterns"/> for several built-in options</param>
         /// <param name="shape">Shape of the agent</param>
         /// <param name="iterationLimit">Maximum number of nodes to check before the path finder gives up</param>
-        /// <returns>Positions along the shortest path from start to end, or an empty array if no path could be found</returns>
-        public Position[] GetPath(Position start, Position end, Offset[] movementPattern, AgentShape shape, int iterationLimit)
+        /// <param name="path">Returns shortest path from start to the end if found. Can also return partial path if end is not reachable. In case of error returns empty array.</param>
+        /// <returns>Result of the path finding.</returns>
+        public PathFindResult TryGetPath(Position start, Position end, Offset[] movementPattern, AgentShape shape, int iterationLimit, out Position[] path)
         {
-            var current = PathFinder.FindPath(this, start, end, movementPattern, shape, iterationLimit);
-
-            if (current == null)
-            {
-                return new Position[0];
-            }
+            var result = PathFinder.TryFindPath(this, start, end, movementPattern, shape, out List<Position> positionList, iterationLimit);
 
             // The Pathfinder returns the positions that found the end. If we want
             // to list positions from start to end we need reverse the traversal.
-            var steps = new Stack<Position>();
+            path = Enumerable.Reverse(positionList).ToArray();
 
-            foreach (var step in current)
-            {
-                steps.Push(step);
-            }
-
-            return steps.ToArray();
+            return result;
         }
 
         /// <summary>

--- a/Roy-T.AStar/PathFindResult.cs
+++ b/Roy-T.AStar/PathFindResult.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace RoyT.AStar
+{
+    /// <summary>
+    /// Path finding result
+    /// </summary>
+    public enum PathFindResult
+    {
+        /// <summary>
+        /// Complete path found from start to end
+        /// </summary>
+        PathFound,
+
+        /// <summary>
+        /// Can't reach the end, but path to closest reachable point is returned
+        /// </summary>
+        PartialPathFound,
+
+        /// <summary>
+        /// Already at the end point
+        /// </summary>
+        AlreadyAtTheEnd,
+
+        /// <summary>
+        /// Start point or some part of agent is outside of map borders
+        /// </summary>
+        StartOutsideBoundaries,
+
+        /// <summary>
+        /// End point is outside of map borders
+        /// </summary>
+        EndOutsideBoundaries,
+    }
+}

--- a/Roy-T.AStar/PathFindResult.cs
+++ b/Roy-T.AStar/PathFindResult.cs
@@ -20,6 +20,11 @@ namespace RoyT.AStar
         PartialPathFound,
 
         /// <summary>
+        /// Happens when agent has no room for movement and can't even get partial path to end
+        /// </summary>
+        Stuck,
+
+        /// <summary>
         /// Already at the end point
         /// </summary>
         AlreadyAtTheEnd,

--- a/Roy-T.AStar/PathFinder.cs
+++ b/Roy-T.AStar/PathFinder.cs
@@ -82,9 +82,16 @@ namespace RoyT.AStar
             }
 
             // Construct path to the closest position
-            MessageCurrent(closestPosition, PartiallyReconstructPath(grid, start, closestPosition, cameFrom));
-            path = ReconstructPath(grid, start, closestPosition, cameFrom);
-            return PathFindResult.PartialPathFound;
+            if (start != closestPosition)
+            {
+                MessageCurrent(closestPosition, PartiallyReconstructPath(grid, start, closestPosition, cameFrom));
+                path = ReconstructPath(grid, start, closestPosition, cameFrom);
+                return PathFindResult.PartialPathFound;
+            }
+
+            // Stuck
+            path = new List<Position>();
+            return PathFindResult.Stuck;
         }
 
         private static void Step(

--- a/Roy-T.AStar/PathFinder.cs
+++ b/Roy-T.AStar/PathFinder.cs
@@ -34,13 +34,7 @@ namespace RoyT.AStar
 
             // To avoid lot of grid boundaries checking calculations during path finding, do the math here.
             // So get the possible boundaries considering the shape of the agent.
-            var boundary = new Boundary()
-            {
-                X1 = -shape.TopLeft.X,
-                Y1 = -shape.TopLeft.Y,
-                X2 = grid.DimX - shape.BottomRight.X - 1,
-                Y2 = grid.DimY - shape.BottomRight.Y - 1
-            };
+            var boundary = Boundary.FromSizeAndShape(grid.DimX, grid.DimY, shape);
 
             // Make sure that agent is within grid. This means agent shape has to be considered.
             if (!boundary.IsInside(start))

--- a/Roy-T.AStar/PathFinder.cs
+++ b/Roy-T.AStar/PathFinder.cs
@@ -42,16 +42,15 @@ namespace RoyT.AStar
                 Y2 = grid.DimY - shape.BottomRight.Y - 1
             };
 
-            // Make sure that agent start position is within boundary
+            // Make sure that agent is within grid. This means agent shape has to be considered.
             if (!boundary.IsInside(start))
             {
                 path = new List<Position>();
                 return PathFindResult.StartOutsideBoundaries;
             }
 
-            // Make sure that end position is within boundary so that the agent can reach it
-            // TODO Maybe the end point shouldn't consider agent shape ?
-            if (!boundary.IsInside(end))
+            // Make sure that end position is within grid
+            if (!grid.IsInside(end))
             {
                 path = new List<Position>();
                 return PathFindResult.EndOutsideBoundaries;

--- a/UnitTests/PathFinderTests.cs
+++ b/UnitTests/PathFinderTests.cs
@@ -9,7 +9,7 @@ namespace UnitTests
         public void NonExistingPathShouldReturnEmtpyArray()
         {
             var grid = GridCatalog.GridWithEnclosedCenterTile();
-            var path = grid.GetPath(new Position(0, 0), new Position(4, 4));
+            var result = grid.TryGetPath(new Position(0, 0), new Position(4, 4), out Position[] path);
 
             Assert.NotNull(path);
             Assert.Empty(path);
@@ -19,7 +19,7 @@ namespace UnitTests
         public void ShouldFindPathInUnobstructedGrid()
         {
             var grid = GridCatalog.UnobstructedGrid();
-            var path = grid.GetPath(new Position(0, 0), new Position(8, 8));
+            var result = grid.TryGetPath(new Position(0, 0), new Position(8, 8), out Position[] path);
 
             Assert.NotNull(path);
             Assert.Equal(9, path.Length);
@@ -29,7 +29,7 @@ namespace UnitTests
         public void ShouldFindPathWithNonZeroStartingPosition()
         {
             var grid = GridCatalog.UnobstructedGrid();
-            var path = grid.GetPath(new Position(3, 3), new Position(5, 3));
+            var result = grid.TryGetPath(new Position(3, 3), new Position(5, 3), out Position[] path);
 
             Assert.NotNull(path);
             Assert.Equal(3, path.Length);
@@ -39,7 +39,7 @@ namespace UnitTests
         public void ShouldRespectBlockedCells()
         {
             var grid = GridCatalog.GridWithBlockedCenterTile();
-            var path = grid.GetPath(new Position(0, 0), new Position(8, 8));
+            var result = grid.TryGetPath(new Position(0, 0), new Position(8, 8), out Position[] path);
 
             Assert.NotNull(path);
             Assert.DoesNotContain(new Position(4, 4), path);
@@ -50,7 +50,7 @@ namespace UnitTests
         public void ShouldRespectCellCost()
         {
             var grid = GridCatalog.GridWithHighCostCenterTile();
-            var path = grid.GetPath(new Position(0, 0), new Position(8, 8));
+            var result = grid.TryGetPath(new Position(0, 0), new Position(8, 8), out Position[] path);
 
             Assert.NotNull(path);
             Assert.DoesNotContain(new Position(4, 4), path);
@@ -61,17 +61,17 @@ namespace UnitTests
         public void ShouldRespectIterationLimit()
         {
             var grid = GridCatalog.UnobstructedGrid();
-            var path = grid.GetPath(new Position(0, 0), new Position(8, 8), MovementPatterns.Full, 8);
+            var result = grid.TryGetPath(new Position(0, 0), new Position(8, 8), MovementPatterns.Full, AgentShapes.Dot, 8, out Position[] path);
 
             Assert.NotNull(path);
-            Assert.Empty(path);            
+            Assert.Empty(path);
         }
 
         [Fact]
         public void ShouldRespectMovementPattern()
         {
             var grid = GridCatalog.GridWithObstructedDiagonals();
-            var path = grid.GetPath(new Position(0, 0), new Position(8, 8), MovementPatterns.LateralOnly);
+            var result = grid.TryGetPath(new Position(0, 0), new Position(8, 8), MovementPatterns.LateralOnly, AgentShapes.Dot, out Position[] path);
 
             Assert.NotNull(path);
             Assert.Empty(path);

--- a/Viewer/PathController.cs
+++ b/Viewer/PathController.cs
@@ -56,8 +56,10 @@ namespace Viewer
                 }
             }
             
-            var path = grid.GetPath(start, end, MovementPatterns.Full, AgentShapes.Dot, iterationLimit);
-            
+            var result = grid.TryGetPath(start, end, MovementPatterns.Full, AgentShapes.Dot, iterationLimit, out Position[] path);
+
+            // TODO Visualize path finding result
+
             // Visualize the path in the cells, skip the start and end node, we already
             // have those in the visualization
             foreach (var p in path.Skip(1).Take(path.Length - 2))
@@ -65,6 +67,6 @@ namespace Viewer
                 var cell = lookup[p];
                 cell.CellState = CellState.OnPath;                
             }
-        }       
+        }
     }
 }


### PR DESCRIPTION
Solves #27 

If path to the end point is not found then at least a path to closest point is returned.
Introduced path finding result enumeration which explain the type of the path:

- PathFindResult.PathFound - Complete path found from start to end
- PathFindResult.PartialPathFound - Can't reach the end, but path to closest reachable point is returned
- PathFindResult.AlreadyAtTheEnd - Already at the end point
- PathFindResult.StartOutsideBoundaries - Start point or some part of agent is outside of map borders
- PathFindResult.EndOutsideBoundaries - End point is outside of map borders

However, this broke the compatibility. There's no more "GetPath" function, instead there's "TryGetPath".

Looks like this:
![image](https://user-images.githubusercontent.com/8956215/68085621-79bde080-fe4b-11e9-8945-725a80768374.png)

@roy-t  - please don't merge yet. I have some TODO's there.
I'm mainly thinking about removing agent shape dependent end point boundary check. It might be better to return partial path to end point rather than returning EndOutsideBoundaries error and no path.
