### PR TITLE
Updating grid test to use deserialized grid node

### DIFF
--- a/Roy-T.AStar.Tests/GridSerializationTests.cs
+++ b/Roy-T.AStar.Tests/GridSerializationTests.cs
@@ -30,7 +30,7 @@ namespace Roy_T.AStar.Tests
                 {
                     var gridPosition = new GridPosition(i, j);
                     var originalNode = grid.GetNode(gridPosition);
-                    var deserializedNode = grid.GetNode(gridPosition);
+                    var deserializedNode = deserializedGrid.GetNode(gridPosition);
                     Assert.AreEqual(originalNode.Position, deserializedNode.Position);
                     Assert.AreEqual(originalNode.Outgoing.Count, deserializedNode.Outgoing.Count);
                     Assert.AreEqual(originalNode.Incoming.Count, deserializedNode.Incoming.Count);


### PR DESCRIPTION
Original test tested node against itself.